### PR TITLE
Configuration accessable to all classes

### DIFF
--- a/lib/cloudkeeper/cli.rb
+++ b/lib/cloudkeeper/cli.rb
@@ -19,12 +19,12 @@ module Cloudkeeper
 
     desc 'sync', 'Runs synchronization process'
     def sync
-      # parameters = initialize_action(options, __method__)
+      initialize_action(options, __method__)
     end
 
     desc 'migrate', 'Discovers and prepares already uploaded appliances'
     def migrate
-      # parameters = initialize_action(options, __method__)
+      initialize_action(options, __method__)
     end
 
     desc 'version', 'Prints cloudkeeper version'
@@ -37,25 +37,26 @@ module Cloudkeeper
     private
 
     def initialize_action(options, action)
-      parameters = options.to_hash.deep_symbolize_keys
-      initialize_logger parameters
-      logger.debug "Cloudkeeper action #{action.inspect} called with parameters: #{parameters.inspect}"
+      initialize_configuration options
+      initialize_logger
+      logger.debug "Cloudkeeper action #{action.inspect} called with parameters: #{Settings.to_hash.inspect}"
+    end
 
-      parameters
+    def initialize_configuration(options)
+      Settings.clear
+      Settings.merge! options.to_hash
     end
 
     # Inits logging according to the settings
     #
-    # @param [Hash] parameters
     # @option parameters [String] logging-level
     # @option parameters [String] logging-file file to log to
     # @option parameters [TrueClass, FalseClass] debug debug mode
-    # @return [Type] description of returned object
-    def initialize_logger(parameters)
-      parameters[:'logging-level'] = 'DEBUG' if parameters[:debug]
+    def initialize_logger
+      Settings[:'logging-level'] = 'DEBUG' if Settings[:debug]
 
-      logging_file = parameters[:'logging-file']
-      logging_level = parameters[:'logging-level']
+      logging_file = Settings[:'logging-file']
+      logging_level = Settings[:'logging-level']
 
       Yell.new :stdout, name: Object, level: logging_level.downcase, format: Yell::DefaultFormat
       Object.send :include, Yell::Loggable


### PR DESCRIPTION
I'm working on the image conversion and I realized I need the `qemu-img` binary path from the configuration file/command line option and it would be really annoying passing the option from CLI, through all the instances to the method where I need it (I learnt that during the `nifty` development).

So I came up with an idea that I will read the configuration file and options from the command line, merge them (command line options taking precedence) and put the final set of parameters back to the `Settings` singleton instance (inherited from `Settingslogic`). That singleton is there anyway, I may as well use it. Methods will have less parameters and I don't have to care about configuration accessibility for each instance. What do you think? Good idea? Bad idea? I'm open to suggestions.